### PR TITLE
Implement Aspect Ratio Cropping

### DIFF
--- a/app/src/main/java/com/tanishranjan/cropkit_demo/MainActivity.kt
+++ b/app/src/main/java/com/tanishranjan/cropkit_demo/MainActivity.kt
@@ -48,7 +48,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.tanishranjan.cropkit.CropDefaults
+import com.tanishranjan.cropkit.CropRatio
 import com.tanishranjan.cropkit.CropShape
+import com.tanishranjan.cropkit.GridLinesType
 import com.tanishranjan.cropkit.ImageCropper
 import com.tanishranjan.cropkit.rememberCropController
 import com.tanishranjan.cropkit_demo.ui.theme.CropKitTheme
@@ -65,12 +67,14 @@ class MainActivity : ComponentActivity() {
             CropKitTheme {
 
                 var image: Bitmap? by remember { mutableStateOf(null) }
-                var cropShape by remember { mutableStateOf(CropShape.RECTANGLE) }
+                var cropShape: CropShape by remember { mutableStateOf(CropShape.Original) }
+                var gridLinesType by remember { mutableStateOf(GridLinesType.GRID) }
                 val cropController = image?.let {
                     rememberCropController(
                         bitmap = it,
                         cropOptions = CropDefaults.cropOptions(
-                            cropShape = cropShape
+                            cropShape = cropShape,
+                            gridLinesType = gridLinesType
                         )
                     )
                 }
@@ -139,39 +143,54 @@ class MainActivity : ComponentActivity() {
                                     SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
 
                                         SegmentedButton(
-                                            selected = cropShape == CropShape.RECTANGLE,
+                                            selected = cropShape == CropShape.FreeForm,
                                             onClick = {
-                                                cropShape = CropShape.RECTANGLE
+                                                cropShape = CropShape.FreeForm
                                             },
                                             shape = SegmentedButtonDefaults.itemShape(
                                                 index = 0,
-                                                count = 3
+                                                count = 4
                                             )
                                         ) {
                                             Text("Free-Form")
                                         }
 
                                         SegmentedButton(
-                                            selected = cropShape == CropShape.SQUARE,
+                                            selected = cropShape == CropShape.Original,
                                             onClick = {
-                                                cropShape = CropShape.SQUARE
+                                                cropShape = CropShape.Original
                                             },
                                             shape = SegmentedButtonDefaults.itemShape(
                                                 index = 1,
-                                                count = 3
+                                                count = 4
+                                            )
+                                        ) {
+                                            Text("Original")
+                                        }
+
+                                        SegmentedButton(
+                                            selected = cropShape is CropShape.AspectRatio && gridLinesType == GridLinesType.CROSSHAIR,
+                                            onClick = {
+                                                cropShape = CropShape.AspectRatio(CropRatio.SQUARE)
+                                                gridLinesType = GridLinesType.CROSSHAIR
+                                            },
+                                            shape = SegmentedButtonDefaults.itemShape(
+                                                index = 2,
+                                                count = 4
                                             )
                                         ) {
                                             Text("Square")
                                         }
 
                                         SegmentedButton(
-                                            selected = cropShape == CropShape.CIRCLE,
+                                            selected = cropShape is CropShape.AspectRatio && gridLinesType == GridLinesType.GRID_AND_CIRCLE,
                                             onClick = {
-                                                cropShape = CropShape.CIRCLE
+                                                cropShape = CropShape.AspectRatio(CropRatio.SQUARE)
+                                                gridLinesType = GridLinesType.GRID_AND_CIRCLE
                                             },
                                             shape = SegmentedButtonDefaults.itemShape(
-                                                index = 2,
-                                                count = 3
+                                                index = 3,
+                                                count = 4
                                             )
                                         ) {
                                             Text("Circle")

--- a/cropkit/build.gradle.kts
+++ b/cropkit/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 android {
     namespace = "com.tanishranjan.cropkit"
     compileSdk = 35
-    version = "1.0.0"
+    version = "1.1.0"
 
     defaultConfig {
         minSdk = 21
@@ -73,7 +73,6 @@ afterEvaluate {
 
                 groupId = "com.github.tanish-ranjan"
                 artifactId = "crop-kit"
-                version = "1.0.0"
             }
         }
     }

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/CropController.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/CropController.kt
@@ -21,7 +21,7 @@ class CropController(
         bitmap = bitmap,
         cropShape = cropOptions.cropShape,
         contentScale = cropOptions.contentScale,
-        gridlines = cropOptions.gridlines,
+        gridLinesVisibility = cropOptions.gridLinesVisibility,
         handleRadius = cropOptions.handleRadius,
         touchPadding = cropOptions.touchPadding
     )

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/CropDefaults.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/CropDefaults.kt
@@ -11,15 +11,17 @@ object CropDefaults {
      * Default crop options for [ImageCropper].
      */
     fun cropOptions(
-        cropShape: CropShape = CropShape.CIRCLE,
+        cropShape: CropShape = CropShape.Original,
         contentScale: ContentScale = ContentScale.Fit,
-        gridlines: Gridlines = Gridlines.ON_TOUCH,
+        gridLinesVisibility: GridLinesVisibility = GridLinesVisibility.ON_TOUCH,
+        gridLinesType: GridLinesType = GridLinesType.GRID,
         handleRadius: Dp = 8.dp,
         touchPadding: Dp = 10.dp
     ) = CropOptions(
         cropShape = cropShape,
         contentScale = contentScale,
-        gridlines = gridlines,
+        gridLinesVisibility = gridLinesVisibility,
+        gridLinesType = gridLinesType,
         handleRadius = handleRadius,
         touchPadding = touchPadding
     )

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/CropOptions.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/CropOptions.kt
@@ -8,14 +8,16 @@ import androidx.compose.ui.unit.Dp
  *
  * @param cropShape The shape of the crop area.
  * @param contentScale The scale type of the image content.
- * @param gridlines The gridlines visibility mode.
+ * @param gridLinesVisibility The gridlines visibility mode.
+ * @param gridLinesType The type of gridlines to be displayed.
  * @param handleRadius The radius of the drag handles.
  * @param touchPadding The padding around the drag handles to increase the touch area.
  */
 data class CropOptions(
     val cropShape: CropShape,
     val contentScale: ContentScale,
-    val gridlines: Gridlines,
+    val gridLinesVisibility: GridLinesVisibility,
+    val gridLinesType: GridLinesType,
     val handleRadius: Dp,
     val touchPadding: Dp
 )

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/CropRatio.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/CropRatio.kt
@@ -1,0 +1,20 @@
+package com.tanishranjan.cropkit
+
+/**
+ * Standard aspect ratios which can be used for [CropShape.AspectRatio].
+ */
+object CropRatio {
+    const val SQUARE = 1f
+    const val PORTRAIT_9_16 = 9f / 16
+    const val LANDSCAPE_16_9 = 16f / 9
+    const val PORTRAIT_4_5 = 4f / 5
+    const val LANDSCAPE_5_4 = 5f / 4
+    const val PORTRAIT_3_4 = 3f / 4
+    const val LANDSCAPE_4_3 = 4f / 3
+    const val PORTRAIT_2_3 = 2f / 3
+    const val LANDSCAPE_3_2 = 3f / 2
+    const val PORTRAIT_5_7 = 5f / 7
+    const val LANDSCAPE_7_5 = 7f / 5
+    const val PORTRAIT_1_2 = 1f / 2
+    const val LANDSCAPE_2_1 = 2f / 1
+}

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/CropShape.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/CropShape.kt
@@ -3,8 +3,8 @@ package com.tanishranjan.cropkit
 /**
  * Enum class representing the shape of the Crop Rectangle.
  */
-enum class CropShape {
-    RECTANGLE,
-    SQUARE,
-    CIRCLE
+sealed class CropShape {
+    data object FreeForm: CropShape()
+    data object Original: CropShape()
+    data class AspectRatio(val ratio: Float): CropShape()
 }

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/GridLinesType.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/GridLinesType.kt
@@ -1,0 +1,11 @@
+package com.tanishranjan.cropkit
+
+/**
+ * Enum class to represent the gridlines type.
+ */
+enum class GridLinesType {
+    GRID,
+    CIRCLE,
+    GRID_AND_CIRCLE,
+    CROSSHAIR
+}

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/GridLinesVisibility.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/GridLinesVisibility.kt
@@ -3,7 +3,7 @@ package com.tanishranjan.cropkit
 /**
  * Enum class to represent the gridlines visibility.
  */
-enum class Gridlines {
+enum class GridLinesVisibility {
     ALWAYS,
     ON_TOUCH,
     NEVER

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropState.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropState.kt
@@ -17,6 +17,7 @@ import com.tanishranjan.cropkit.HandlesRect
  * @param canvasSize The size of the canvas.
  * @param isDragging Whether the user is dragging the crop rectangle or any of its handles.
  * @param gridlinesActive Whether the gridlines are active.
+ * @param aspectRatio The aspect ratio of the crop rectangle.
  */
 internal data class CropState(
     val bitmap: Bitmap,
@@ -26,5 +27,6 @@ internal data class CropState(
     val handles: HandlesRect = HandlesRect(),
     val canvasSize: Size = Size.Zero,
     val isDragging: Boolean = false,
-    val gridlinesActive: Boolean = false
+    val gridlinesActive: Boolean = false,
+    val aspectRatio: Float = 0f
 )

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/util/Extensions.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/util/Extensions.kt
@@ -10,6 +10,4 @@ internal object Extensions {
         return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom
     }
 
-    fun CropShape.isSquareBounds(): Boolean = this == CropShape.SQUARE || this == CropShape.CIRCLE
-
 }


### PR DESCRIPTION
## Description
This update now developers to apply any desired aspect ratio for the crop rectangle.

## Changes
- Refactored `CropShape` with a new `AspectRatio` option to allow cropping with fixed aspect ratios.
- Added `CropShape.Original` to maintain the image's original aspect ratio.
- Renamed `Gridlines` enum to `GridLinesVisibility` for clarity.
- Introduced a new enum `GridLinesType` customize the visual appearance of gridlines.
- Updated `CropOptions` to include `gridLinesType`.
- Modified `ImageCropper` to draw gridlines based on `gridLinesType` and `gridLinesVisibility`.
- The dark overlay outside the crop area now considers `gridLinesType` to determine its shape (rectangle or oval).
- Updated `CropStateManager` to handle aspect ratio constraints during dragging and initialization.
- Added `CropRatio` object with predefined common aspect ratios.
- Updated the demo app to showcase new aspect ratio and gridline features.
- Bumped library version to 1.1.0.
- Removed `isSquareBounds()` extension function as it's no longer needed with the new `CropShape` sealed class.
Please include a summary of the changes and the related issue. Please also include relevant
motivation and context. List any dependencies that are required for this change.

## Type of change

- [x] New feature (non-breaking change which adds functionality)