### PR TITLE
Fix coerceIn crash when maximum < minimum in moveCropRect

### DIFF
--- a/cropkit/src/main/java/com/tanishranjan/cropkit/CropController.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/CropController.kt
@@ -36,6 +36,11 @@ class CropController(
      */
     fun crop(): Bitmap = stateManager.crop()
 
+    fun cropBitmap(targetBitmap: Bitmap): Bitmap {
+        return cropStateManager.cropBitmap(targetBitmap)
+    }
+
+
     /**
      * Rotates the bitmap clockwise in the ImageCropper.
      */

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/CropController.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/CropController.kt
@@ -37,7 +37,7 @@ class CropController(
     fun crop(): Bitmap = stateManager.crop()
 
     fun cropBitmap(targetBitmap: Bitmap): Bitmap {
-        return cropStateManager.cropBitmap(targetBitmap)
+        return stateManager.cropBitmap(targetBitmap)
     }
 
 

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropStateManager.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropStateManager.kt
@@ -56,6 +56,35 @@ internal class CropStateManager(
         reset(bitmap)
     }
 
+    fun cropBitmap(targetBitmap: Bitmap): Bitmap {
+        val state = state.value
+        val originalBitmap = state.bitmap
+        val imageRect = state.imageRect
+        val cropRect = state.cropRect
+    
+        // Calculate scale factors between original UI bitmap and target bitmap
+        val scaleX = targetBitmap.width.toFloat() / originalBitmap.width.toFloat()
+        val scaleY = targetBitmap.height.toFloat() / originalBitmap.height.toFloat()
+    
+        // Calculate crop coordinates for target bitmap
+        val cropX = ((cropRect.left - imageRect.left) * scaleX).toInt()
+        val cropY = ((cropRect.top - imageRect.top) * scaleY).toInt()
+        val cropWidth = (cropRect.width * scaleX).toInt()
+        val cropHeight = (cropRect.height * scaleY).toInt()
+    
+        val x = cropX.coerceIn(0, targetBitmap.width)
+        val y = cropY.coerceIn(0, targetBitmap.height)
+        val width = cropWidth.coerceIn(0, targetBitmap.width - x)
+        val height = cropHeight.coerceIn(0, targetBitmap.height - y)
+    
+        return Bitmap.createBitmap(
+            targetBitmap,
+            x, y,
+            width, height
+        )
+    }
+
+
     fun updateCanvasSize(canvasSize: Size) {
         setState(canvasSize, state.value.bitmap)
     }

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropStateManager.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropStateManager.kt
@@ -52,8 +52,37 @@ internal class CropStateManager(
     }
     }
 
+    data class CropCoordinates(
+        val x: Int,
+        val y: Int,
+        val width: Int,
+        val height: Int
+    )
+
     init {
         reset(bitmap)
+    }
+
+    fun getCropCoordinates(): CropCoordinates {
+        val state = state.value
+        val bitmap = state.bitmap
+        val imageRect = state.imageRect
+        val cropRect = state.cropRect
+    
+        val scaleX = bitmap.width / imageRect.width
+        val scaleY = bitmap.height / imageRect.height
+    
+        val cropX = ((cropRect.left - imageRect.left) * scaleX).toInt()
+        val cropY = ((cropRect.top - imageRect.top) * scaleY).toInt()
+        val cropWidth = (cropRect.width * scaleX).toInt()
+        val cropHeight = (cropRect.height * scaleY).toInt()
+    
+        return CropCoordinates(
+            x = cropX.coerceIn(0, bitmap.width),
+            y = cropY.coerceIn(0, bitmap.height),
+            width = cropWidth.coerceIn(0, bitmap.width - cropX),
+            height = cropHeight.coerceIn(0, bitmap.height - cropY)
+        )
     }
 
     fun cropBitmap(targetBitmap: Bitmap): Bitmap {


### PR DESCRIPTION
## Description

Bug fix (non-breaking change which fixes an issue)

Library was crashing with some photos and especially aspect ratio 1:1.

**Fixed:** Fix coerceIn crash when maximum < minimum in moveCropRect

The error was:
`
java.lang.IllegalArgumentException: Cannot coerce value to an empty range: maximum 252.04541 is less than minimum 252.04544.
                                                                                                    	at kotlin.ranges.RangesKt___RangesKt.coerceIn(_Ranges.kt:1476)
                                                                                                    	at com.tanishranjan.cropkit.internal.CropStateManager.moveCropRect-k-4lQ0M(CropStateManager.kt:150)
                                                                                                    	at com.tanishranjan.cropkit.internal.CropStateManager.onDrag-k-4lQ0M(CropStateManager.kt:117)
                                                                                                    	at com.tanishranjan.cropkit.CropController.onStateChange$cropkit_release(CropController.kt:63)
                                                                                                    	at com.tanishranjan.cropkit.ImageCropperKt$ImageCropper$1$1$1.invoke$lambda$2(ImageCropper.kt:83)
                                                                                                    	at com.tanishranjan.cropkit.ImageCropperKt$ImageCropper$1$1$1.$r8$lambda$DAhhGuPEQyFYDTlMI0R5poPBBlI(Unknown Source:0)
                                                                                                    	at com.tanishranjan.cropkit.ImageCropperKt$ImageCropper$1$1$1$$ExternalSyntheticLambda2.invoke(D8$$SyntheticClass:0)
                                                                                                    	at androidx.compose.foundation.gestures.DragGestureDetectorKt$detectDragGestures$9.invokeSuspend(DragGestureDetector.kt:306)
                                                                                                    	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
                                                                                                    	at kotlinx.coroutines.DispatchedTaskKt.resume(DispatchedTask.kt:163)
                                                                                                    	at kotlinx.coroutines.DispatchedTaskKt.dispatch(DispatchedTask.kt:152)
                                                                                                    	at kotlinx.coroutines.CancellableContinuationImpl.dispatchResume(CancellableContinuationImpl.kt:470)
                                                                                                    	at kotlinx.coroutines.CancellableContinuationImpl.resumeImpl$kotlinx_coroutines_core(CancellableContinuationImpl.kt:504)
                                                                                                    	at kotlinx.coroutines.CancellableContinuationImpl.resumeImpl$kotlinx_coroutines_core$default(CancellableContinuationImpl.kt:493)
                                                                                                    	at kotlinx.coroutines.CancellableContinuationImpl.resumeWith(CancellableContinuationImpl.kt:359)
                                                                                                    	at androidx.compose.ui.input.pointer.SuspendingPointerInputModifierNodeImpl$PointerEventHandlerCoroutine.offerPointerEvent(SuspendingPointerInputFilter.kt:830)
                                                                                                    	at androidx.compose.ui.input.pointer.SuspendingPointerInputModifierNodeImpl.dispatchPointerEvent(SuspendingPointerInputFilter.kt:698)
                                                                                                    	at androidx.compose.ui.input.pointer.SuspendingPointerInputModifierNodeImpl.onPointerEvent-H0pRuoY(SuspendingPointerInputFilter.kt:724)
                                                                                                    	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:436)
                                                                                                    	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:422)
                                                                                                    	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:422)
                                                                                                    	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:422)
                                                                                                    	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:422)
                                                                                                    	at androidx.compose.ui.input.pointer.NodeParent.dispatchMainEventPass(HitPathTracker.kt:275)
                                                                                                    	at androidx.compose.ui.input.pointer.HitPathTracker.dispatchChanges(HitPathTracker.kt:171)
                                                                                                    	at androidx.compose.ui.input.pointer.PointerInputEventProcessor.process-BIzXfog(PointerInputEventProcessor.kt:117)
                                                                                                    	at androidx.compose.ui.platform.AndroidComposeView.sendMotionEvent-8iAsVTc(AndroidComposeView.android.kt:2370)
                                                                                                    	at androidx.compose.ui.platform.AndroidComposeView.handleMotionEvent-8iAsVTc(AndroidComposeView.android.kt:2320)
                                                                                                    	at androidx.compose.ui.platform.AndroidComposeView.dispatchTouchEvent(AndroidComposeView.android.kt:2191)
                                                                                                    	at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:3133)
                                                                                                    	at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2814)
                                                                                                    	at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:3133)
                                                                                                    	at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2814)
                                                                                                    	at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:3133)
                                                                                                    	at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2814)
                                                                                                    	at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:3133)
                                                                                                    	at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2814)
                                                                                                    	at com.android.internal.policy.DecorView.superDispatchTouchEvent(DecorView.java:571)`