### PR TITLE
fix for crash while moving crop rectangle

### DIFF
--- a/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropStateManager.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropStateManager.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.core.graphics.scale
 import com.tanishranjan.cropkit.CropShape
 import com.tanishranjan.cropkit.GridLinesVisibility
+import com.tanishranjan.cropkit.util.Extensions.coerceInOrderAgnostic
 import com.tanishranjan.cropkit.util.Extensions.isInsideRect
 import com.tanishranjan.cropkit.util.GestureUtils
 import com.tanishranjan.cropkit.util.MathUtils
@@ -144,10 +145,14 @@ internal class CropStateManager(
         val currentRect = state.value.cropRect
         val imageRect = state.value.imageRect
 
-        val newLeft = (currentRect.left + dragAmount.x)
-            .coerceIn(imageRect.left, imageRect.right - currentRect.width)
-        val newTop = (currentRect.top + dragAmount.y)
-            .coerceIn(imageRect.top, imageRect.bottom - currentRect.height)
+        val newLeft = (currentRect.left + dragAmount.x).coerceInOrderAgnostic(
+            imageRect.left,
+            imageRect.right - currentRect.width
+        )
+        val newTop = (currentRect.top + dragAmount.y).coerceInOrderAgnostic(
+            imageRect.top,
+            imageRect.bottom - currentRect.height
+        )
 
         val newRect = Rect(
             left = newLeft,

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/util/Extensions.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/util/Extensions.kt
@@ -2,7 +2,6 @@ package com.tanishranjan.cropkit.util
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
-import com.tanishranjan.cropkit.CropShape
 
 internal object Extensions {
 
@@ -10,4 +9,9 @@ internal object Extensions {
         return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom
     }
 
+    fun Float.coerceInOrderAgnostic(a: Float, b: Float): Float {
+        val min = minOf(a, b)
+        val max = maxOf(a, b)
+        return this.coerceIn(min, max)
+    }
 }


### PR DESCRIPTION
## Description

I use CropKit for cropping in my app. On some devices I get crashes when moving or dragging the crop box. 
It looks like because of rounding issues the min is sometimes higher than the max.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

I am currently not able to reproduce these crashes myself, I only see them in my crashlytics.

## Checklist:

- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my own code
- [ x ] My changes generate no new warnings