### PR TITLE
#9 Feat: Add content padding to canvas scaling for better touch handl…

### DIFF
--- a/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropStateManager.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropStateManager.kt
@@ -23,7 +23,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.math.abs
-import kotlin.math.ceil
 
 internal class CropStateManager(
     bitmap: Bitmap,
@@ -304,7 +303,7 @@ internal class CropStateManager(
 
         // Add content padding equal to touchPadding so handles at edges
         // always have their full touch area within the canvas bounds
-        val contentPadding = ceil(touchPadding.value) * density
+        val contentPadding = touchPadding.value * density
         val availableWidth = canvasSize.width - contentPadding * 2
         val availableHeight = canvasSize.height - contentPadding * 2
 

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropStateManager.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropStateManager.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.math.abs
+import kotlin.math.ceil
 
 internal class CropStateManager(
     bitmap: Bitmap,
@@ -301,18 +302,25 @@ internal class CropStateManager(
         val imageWidth = bitmap.width.toFloat()
         val imageHeight = bitmap.height.toFloat()
 
+        // Add content padding equal to touchPadding so handles at edges
+        // always have their full touch area within the canvas bounds
+        val contentPadding = ceil(touchPadding.value) * density
+        val availableWidth = canvasSize.width - contentPadding * 2
+        val availableHeight = canvasSize.height - contentPadding * 2
+
         val scaledSize = MathUtils.calculateScaledSize(
             srcWidth = imageWidth,
             srcHeight = imageHeight,
-            dstWidth = canvasSize.width,
-            dstHeight = canvasSize.height,
+            dstWidth = availableWidth,
+            dstHeight = availableHeight,
             contentScale = contentScale
         )
 
         val newBitmap = bitmap.scale(scaledSize.width.toInt(), scaledSize.height.toInt())
 
-        val offsetX = (canvasSize.width - scaledSize.width) / 2f
-        val offsetY = (canvasSize.height - scaledSize.height) / 2f
+        // Center within available space, then add padding offset
+        val offsetX = contentPadding + (availableWidth - scaledSize.width) / 2f
+        val offsetY = contentPadding + (availableHeight - scaledSize.height) / 2f
 
         val aspectRatio = when (cropShape) {
             is CropShape.FreeForm -> null


### PR DESCRIPTION
…e accessibility

- Introduced `contentPadding` based on `touchPadding` to ensure crop handles at the edges remain within the interactive canvas bounds.
- Updated `scaledSize` calculation and offset positioning to account for the new padding, centering the bitmap within the available padded space.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details
for your test configuration.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings