### PR TITLE
feat: improve crop mathematics and expand touch padding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ We welcome contributions of all kinds, including:
 - **Code Contributions:** We love pull requests!  If you'd like to fix a bug, add a new component, or improve existing code, follow these steps:
 
     1. **Fork the Repository:** Click the "Fork" button at the top right of the repository page.
-    2. **Create a Branch:** Create a new branch for your changes.  Use a descriptive name like `fix/drag-gesture` or `add/vertical-gridline`.
+    2. **Create a Branch:** Create a new branch for your changes.  Use a descriptive name like `fix/drag-gesture` or `feat/vertical-gridline`.
     3. **Make Your Changes:** Implement your changes, following the project's coding style and conventions.
     4. **Write Tests:** If applicable, add or update tests to ensure your changes work as expected.
     5. **Commit Your Changes:** Commit your changes with clear and concise commit messages.

--- a/README.md
+++ b/README.md
@@ -5,10 +5,18 @@ yet customizable crop composable to style embed it in your app seamlessly.
 
 ## ✨ Features
 
-- Provides three crop shapes: Rectangle, Square, and Circle.
-- Allows flipping the image vertically or horizontally.
-- Image can be rotated clockwise and anti-clockwise by 90 degrees.
-- Gridlines can be enabled or disabled.
+- Choose from a variety of crop shapes including:
+    - Free Form: Crop to any desired rectangular size.
+    - Original: Maintain image's original aspect ratio during cropping.
+    - Aspect Ratio: Specify any custom aspect ratio (1:1, 16:9, 4:3, etc.) for precise and
+      consistent cropping.
+- Image Transformations:
+    - Flip images vertically or horizontally.
+    - Rotate images clockwise or anti-clockwise by 90 degrees.
+- Customize GridLines:
+    - Gridlines can be set to be always visible, be visible on touch or never be visible.
+    - Several types of gridlines are available such as crosshair, 3x3 grid, circle, 3x3 grid with
+      circle.
 
 ## Preview
 

--- a/app/src/main/java/com/tanishranjan/cropkit_demo/MainActivity.kt
+++ b/app/src/main/java/com/tanishranjan/cropkit_demo/MainActivity.kt
@@ -48,7 +48,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.tanishranjan.cropkit.CropDefaults
+import com.tanishranjan.cropkit.CropRatio
 import com.tanishranjan.cropkit.CropShape
+import com.tanishranjan.cropkit.GridLinesType
 import com.tanishranjan.cropkit.ImageCropper
 import com.tanishranjan.cropkit.rememberCropController
 import com.tanishranjan.cropkit_demo.ui.theme.CropKitTheme
@@ -65,12 +67,14 @@ class MainActivity : ComponentActivity() {
             CropKitTheme {
 
                 var image: Bitmap? by remember { mutableStateOf(null) }
-                var cropShape by remember { mutableStateOf(CropShape.RECTANGLE) }
+                var cropShape: CropShape by remember { mutableStateOf(CropShape.Original) }
+                var gridLinesType by remember { mutableStateOf(GridLinesType.GRID) }
                 val cropController = image?.let {
                     rememberCropController(
                         bitmap = it,
                         cropOptions = CropDefaults.cropOptions(
-                            cropShape = cropShape
+                            cropShape = cropShape,
+                            gridLinesType = gridLinesType
                         )
                     )
                 }
@@ -139,39 +143,54 @@ class MainActivity : ComponentActivity() {
                                     SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
 
                                         SegmentedButton(
-                                            selected = cropShape == CropShape.RECTANGLE,
+                                            selected = cropShape == CropShape.FreeForm,
                                             onClick = {
-                                                cropShape = CropShape.RECTANGLE
+                                                cropShape = CropShape.FreeForm
                                             },
                                             shape = SegmentedButtonDefaults.itemShape(
                                                 index = 0,
-                                                count = 3
+                                                count = 4
                                             )
                                         ) {
                                             Text("Free-Form")
                                         }
 
                                         SegmentedButton(
-                                            selected = cropShape == CropShape.SQUARE,
+                                            selected = cropShape == CropShape.Original,
                                             onClick = {
-                                                cropShape = CropShape.SQUARE
+                                                cropShape = CropShape.Original
                                             },
                                             shape = SegmentedButtonDefaults.itemShape(
                                                 index = 1,
-                                                count = 3
+                                                count = 4
+                                            )
+                                        ) {
+                                            Text("Original")
+                                        }
+
+                                        SegmentedButton(
+                                            selected = cropShape is CropShape.AspectRatio && gridLinesType == GridLinesType.CROSSHAIR,
+                                            onClick = {
+                                                cropShape = CropShape.AspectRatio(CropRatio.SQUARE)
+                                                gridLinesType = GridLinesType.CROSSHAIR
+                                            },
+                                            shape = SegmentedButtonDefaults.itemShape(
+                                                index = 2,
+                                                count = 4
                                             )
                                         ) {
                                             Text("Square")
                                         }
 
                                         SegmentedButton(
-                                            selected = cropShape == CropShape.CIRCLE,
+                                            selected = cropShape is CropShape.AspectRatio && gridLinesType == GridLinesType.GRID_AND_CIRCLE,
                                             onClick = {
-                                                cropShape = CropShape.CIRCLE
+                                                cropShape = CropShape.AspectRatio(CropRatio.SQUARE)
+                                                gridLinesType = GridLinesType.GRID_AND_CIRCLE
                                             },
                                             shape = SegmentedButtonDefaults.itemShape(
-                                                index = 2,
-                                                count = 3
+                                                index = 3,
+                                                count = 4
                                             )
                                         ) {
                                             Text("Circle")

--- a/cropkit/build.gradle.kts
+++ b/cropkit/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 android {
     namespace = "com.tanishranjan.cropkit"
     compileSdk = 35
-    version = "1.0.0"
+    version = "1.1.0"
 
     defaultConfig {
         minSdk = 21
@@ -73,7 +73,6 @@ afterEvaluate {
 
                 groupId = "com.github.tanish-ranjan"
                 artifactId = "crop-kit"
-                version = "1.0.0"
             }
         }
     }

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/CropController.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/CropController.kt
@@ -21,7 +21,7 @@ class CropController(
         bitmap = bitmap,
         cropShape = cropOptions.cropShape,
         contentScale = cropOptions.contentScale,
-        gridlines = cropOptions.gridlines,
+        gridLinesVisibility = cropOptions.gridLinesVisibility,
         handleRadius = cropOptions.handleRadius,
         touchPadding = cropOptions.touchPadding
     )

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/CropController.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/CropController.kt
@@ -64,5 +64,4 @@ class CropController(
             is CropStateChangeActions.CanvasSizeChanged -> stateManager.updateCanvasSize(action.size)
         }
     }
-
 }

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/CropDefaults.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/CropDefaults.kt
@@ -11,15 +11,17 @@ object CropDefaults {
      * Default crop options for [ImageCropper].
      */
     fun cropOptions(
-        cropShape: CropShape = CropShape.CIRCLE,
+        cropShape: CropShape = CropShape.Original,
         contentScale: ContentScale = ContentScale.Fit,
-        gridlines: Gridlines = Gridlines.ON_TOUCH,
+        gridLinesVisibility: GridLinesVisibility = GridLinesVisibility.ON_TOUCH,
+        gridLinesType: GridLinesType = GridLinesType.GRID,
         handleRadius: Dp = 8.dp,
         touchPadding: Dp = 10.dp
     ) = CropOptions(
         cropShape = cropShape,
         contentScale = contentScale,
-        gridlines = gridlines,
+        gridLinesVisibility = gridLinesVisibility,
+        gridLinesType = gridLinesType,
         handleRadius = handleRadius,
         touchPadding = touchPadding
     )

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/CropDefaults.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/CropDefaults.kt
@@ -16,7 +16,7 @@ object CropDefaults {
         gridLinesVisibility: GridLinesVisibility = GridLinesVisibility.ON_TOUCH,
         gridLinesType: GridLinesType = GridLinesType.GRID,
         handleRadius: Dp = 8.dp,
-        touchPadding: Dp = 10.dp
+        touchPadding: Dp = 20.dp
     ) = CropOptions(
         cropShape = cropShape,
         contentScale = contentScale,

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/CropOptions.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/CropOptions.kt
@@ -8,14 +8,16 @@ import androidx.compose.ui.unit.Dp
  *
  * @param cropShape The shape of the crop area.
  * @param contentScale The scale type of the image content.
- * @param gridlines The gridlines visibility mode.
+ * @param gridLinesVisibility The gridlines visibility mode.
+ * @param gridLinesType The type of gridlines to be displayed.
  * @param handleRadius The radius of the drag handles.
  * @param touchPadding The padding around the drag handles to increase the touch area.
  */
 data class CropOptions(
     val cropShape: CropShape,
     val contentScale: ContentScale,
-    val gridlines: Gridlines,
+    val gridLinesVisibility: GridLinesVisibility,
+    val gridLinesType: GridLinesType,
     val handleRadius: Dp,
     val touchPadding: Dp
 )

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/CropRatio.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/CropRatio.kt
@@ -1,0 +1,20 @@
+package com.tanishranjan.cropkit
+
+/**
+ * Standard aspect ratios which can be used for [CropShape.AspectRatio].
+ */
+object CropRatio {
+    const val SQUARE = 1f
+    const val PORTRAIT_9_16 = 9f / 16
+    const val LANDSCAPE_16_9 = 16f / 9
+    const val PORTRAIT_4_5 = 4f / 5
+    const val LANDSCAPE_5_4 = 5f / 4
+    const val PORTRAIT_3_4 = 3f / 4
+    const val LANDSCAPE_4_3 = 4f / 3
+    const val PORTRAIT_2_3 = 2f / 3
+    const val LANDSCAPE_3_2 = 3f / 2
+    const val PORTRAIT_5_7 = 5f / 7
+    const val LANDSCAPE_7_5 = 7f / 5
+    const val PORTRAIT_1_2 = 1f / 2
+    const val LANDSCAPE_2_1 = 2f / 1
+}

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/CropShape.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/CropShape.kt
@@ -3,8 +3,8 @@ package com.tanishranjan.cropkit
 /**
  * Enum class representing the shape of the Crop Rectangle.
  */
-enum class CropShape {
-    RECTANGLE,
-    SQUARE,
-    CIRCLE
+sealed class CropShape {
+    data object FreeForm: CropShape()
+    data object Original: CropShape()
+    data class AspectRatio(val ratio: Float): CropShape()
 }

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/GridLinesType.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/GridLinesType.kt
@@ -1,0 +1,11 @@
+package com.tanishranjan.cropkit
+
+/**
+ * Enum class to represent the gridlines type.
+ */
+enum class GridLinesType {
+    GRID,
+    CIRCLE,
+    GRID_AND_CIRCLE,
+    CROSSHAIR
+}

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/GridLinesVisibility.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/GridLinesVisibility.kt
@@ -3,7 +3,7 @@ package com.tanishranjan.cropkit
 /**
  * Enum class to represent the gridlines visibility.
  */
-enum class Gridlines {
+enum class GridLinesVisibility {
     ALWAYS,
     ON_TOUCH,
     NEVER

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/ImageCropper.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/ImageCropper.kt
@@ -203,9 +203,7 @@ fun ImageCropper(
                         style = Fill
                     )
                 }
-
             }
-
         }
     }
 

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropState.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropState.kt
@@ -17,6 +17,7 @@ import com.tanishranjan.cropkit.HandlesRect
  * @param canvasSize The size of the canvas.
  * @param isDragging Whether the user is dragging the crop rectangle or any of its handles.
  * @param gridlinesActive Whether the gridlines are active.
+ * @param aspectRatio The aspect ratio of the crop rectangle.
  */
 internal data class CropState(
     val bitmap: Bitmap,
@@ -26,5 +27,6 @@ internal data class CropState(
     val handles: HandlesRect = HandlesRect(),
     val canvasSize: Size = Size.Zero,
     val isDragging: Boolean = false,
-    val gridlinesActive: Boolean = false
+    val gridlinesActive: Boolean = false,
+    val aspectRatio: Float = 0f
 )

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropState.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropState.kt
@@ -1,7 +1,6 @@
 package com.tanishranjan.cropkit.internal
 
 import android.graphics.Bitmap
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.ImageBitmap
@@ -12,7 +11,6 @@ import com.tanishranjan.cropkit.HandlesRect
  *
  * @param bitmap The bitmap of the image.
  * @param imageBitmap The image bitmap of the image.
- * @param dragOffset The offset of the drag.
  * @param cropRect The crop rectangle.
  * @param imageRect The image rectangle.
  * @param handles The handles rectangles of the crop rectangle.
@@ -24,7 +22,6 @@ import com.tanishranjan.cropkit.HandlesRect
 internal data class CropState(
     val bitmap: Bitmap,
     val imageBitmap: ImageBitmap? = null,
-    val dragOffset: Offset = Offset.Zero,
     val cropRect: Rect = Rect.Zero,
     val imageRect: Rect = Rect.Zero,
     val handles: HandlesRect = HandlesRect(),

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropState.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropState.kt
@@ -1,6 +1,7 @@
 package com.tanishranjan.cropkit.internal
 
 import android.graphics.Bitmap
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.ImageBitmap
@@ -11,6 +12,7 @@ import com.tanishranjan.cropkit.HandlesRect
  *
  * @param bitmap The bitmap of the image.
  * @param imageBitmap The image bitmap of the image.
+ * @param dragOffset The offset of the drag.
  * @param cropRect The crop rectangle.
  * @param imageRect The image rectangle.
  * @param handles The handles rectangles of the crop rectangle.
@@ -22,6 +24,7 @@ import com.tanishranjan.cropkit.HandlesRect
 internal data class CropState(
     val bitmap: Bitmap,
     val imageBitmap: ImageBitmap? = null,
+    val dragOffset: Offset = Offset.Zero,
     val cropRect: Rect = Rect.Zero,
     val imageRect: Rect = Rect.Zero,
     val handles: HandlesRect = HandlesRect(),

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropStateManager.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropStateManager.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlin.math.abs
 
 internal class CropStateManager(
     bitmap: Bitmap,
@@ -77,17 +76,24 @@ internal class CropStateManager(
     }
 
     fun onDragStart(offset: Offset) {
-
         val activeHandle = findActiveHandle(offset)
+        val currentRect = state.value.cropRect
 
         dragMode = when {
             activeHandle != null -> DragMode.Handle(activeHandle)
-            offset.isInsideRect(state.value.cropRect) -> DragMode.Move
+            offset.isInsideRect(currentRect) -> DragMode.Move
             else -> DragMode.None
+        }
+
+        val dragOffset = when (val mode = dragMode) {
+            DragMode.None -> Offset.Zero
+            DragMode.Move -> Offset(currentRect.left, currentRect.top)
+            is DragMode.Handle -> GestureUtils.getHandleOffset(mode.handle, currentRect)
         }
 
         _state.update { cropState ->
             cropState.copy(
+                dragOffset = dragOffset,
                 isDragging = dragMode != DragMode.None,
                 gridlinesActive = if (gridLinesVisibility == GridLinesVisibility.ON_TOUCH) {
                     dragMode != DragMode.None
@@ -113,10 +119,8 @@ internal class CropStateManager(
 
     fun onDrag(dragAmount: Offset) {
         when (val dragMode = dragMode) {
-            is DragMode.Handle -> dragHandles(dragMode.handle, dragAmount)
-
+            is DragMode.Handle -> moveDragHandle(dragMode.handle, dragAmount)
             DragMode.Move -> moveCropRect(dragAmount)
-
             DragMode.None -> {}
         }
     }
@@ -141,15 +145,19 @@ internal class CropStateManager(
     }
 
     private fun moveCropRect(dragAmount: Offset) {
-
         val currentRect = state.value.cropRect
         val imageRect = state.value.imageRect
 
-        val newLeft = (currentRect.left + dragAmount.x).coerceInOrderAgnostic(
+        val correctedDragAmount = GestureUtils.getCorrectDragAmount(
+            dragOffset = state.value.dragOffset,
+            dragAmount = dragAmount
+        )
+
+        val newLeft = correctedDragAmount.x.coerceInOrderAgnostic(
             imageRect.left,
             imageRect.right - currentRect.width
         )
-        val newTop = (currentRect.top + dragAmount.y).coerceInOrderAgnostic(
+        val newTop = correctedDragAmount.y.coerceInOrderAgnostic(
             imageRect.top,
             imageRect.bottom - currentRect.height
         )
@@ -163,29 +171,30 @@ internal class CropStateManager(
 
         _state.update {
             it.copy(
+                dragOffset = correctedDragAmount,
                 cropRect = newRect,
                 handles = GestureUtils.getNewHandleMeasures(newRect, handleRadiusPx)
             )
         }
-
     }
 
-    private fun dragHandles(activeHandle: DragHandle, dragAmount: Offset) {
-        val adjustedDragAmount = if (cropShape is CropShape.FreeForm) {
-            dragAmount
-        } else {
-            getDragAmountForShape(dragAmount, activeHandle)
-        }
+    private fun moveDragHandle(activeHandle: DragHandle, dragAmount: Offset) {
+        val correctedDragAmount = GestureUtils.getCorrectDragAmount(
+            dragOffset = state.value.dragOffset,
+            dragAmount = dragAmount
+        )
 
-        GestureUtils.getNewRectMeasures(
+        GestureUtils.calculateNewCropRect(
             activeHandle = activeHandle,
-            dragAmount = adjustedDragAmount,
+            handleOffset = correctedDragAmount,
             imageRect = state.value.imageRect,
             cropRect = state.value.cropRect,
-            minCropSize = MIN_CROP_SIZE
-        )?.let { newRect ->
+            minCropSize = MIN_CROP_SIZE,
+            aspectRatio = state.value.aspectRatio
+        ).let { newRect ->
             _state.update {
                 it.copy(
+                    dragOffset = correctedDragAmount,
                     cropRect = newRect,
                     handles = GestureUtils.getNewHandleMeasures(
                         newRect,
@@ -196,74 +205,9 @@ internal class CropStateManager(
         }
     }
 
-    private fun getDragAmountForShape(dragAmount: Offset, handle: DragHandle): Offset {
-
-        val aspectRatio = state.value.aspectRatio
-        val dx = dragAmount.x
-        val dy = dragAmount.y
-        val xConstraint = abs(dragAmount.x)
-        val xConstraintDeltaY = xConstraint / aspectRatio
-        val yConstraint = abs(dragAmount.y)
-        val yConstraintDeltaX = yConstraint * aspectRatio
-
-        return when (handle) {
-            DragHandle.TopLeft -> {
-                val sign = if (dx < 0 && dy < 0) -1 else 1 // prioritize cropping in
-                val xConstraintCropIn = minOf(xConstraint, xConstraintDeltaY)
-                val yConstraintCropIn = minOf(yConstraint, yConstraintDeltaX)
-                return if (xConstraintCropIn <= yConstraintCropIn) {
-                    Offset(sign * xConstraint, sign * xConstraintDeltaY)
-                } else {
-                    Offset(sign * yConstraintDeltaX, sign * yConstraint)
-                }
-            }
-
-            DragHandle.TopRight -> {
-                val sign = if (dx > 0 && dy < 0) -1 else 1 // prioritize cropping in
-                val xConstraintCropIn = minOf(xConstraint, xConstraintDeltaY)
-                val yConstraintCropIn = minOf(yConstraint, yConstraintDeltaX)
-                return if (xConstraintCropIn <= yConstraintCropIn) {
-                    Offset(-sign * xConstraint, sign * xConstraintDeltaY)
-                } else {
-                    Offset(-sign * yConstraintDeltaX, sign * yConstraint)
-                }
-
-            }
-
-            DragHandle.BottomLeft -> {
-                val sign = if (dx < 0 && dy > 0) -1 else 1 // prioritize cropping in
-                val xConstraintCropIn = minOf(xConstraint, xConstraintDeltaY)
-                val yConstraintCropIn = minOf(yConstraint, yConstraintDeltaX)
-                return if (xConstraintCropIn <= yConstraintCropIn) {
-                    Offset(sign * xConstraint, -sign * xConstraintDeltaY)
-                } else {
-                    Offset(sign * yConstraintDeltaX, -sign * yConstraint)
-                }
-            }
-
-            DragHandle.BottomRight -> {
-                val sign = if (dx > 0 && dy > 0) -1 else 1 // prioritize cropping in
-                val xConstraintCropIn = minOf(xConstraint, xConstraintDeltaY)
-                val yConstraintCropIn = minOf(yConstraint, yConstraintDeltaX)
-                return if (xConstraintCropIn <= yConstraintCropIn) {
-                    Offset(-sign * xConstraint, -sign * xConstraintDeltaY)
-                } else {
-                    Offset(-sign * yConstraintDeltaX, -sign * yConstraint)
-                }
-            }
-
-            else -> Offset.Zero
-        }
-
-    }
-
     private fun findActiveHandle(offset: Offset): DragHandle? {
-        // TODO: Allow cropping with all handles in locked aspect ratios
-        val handles = if (cropShape is CropShape.FreeForm) {
-            state.value.handles.getAllNamedHandles()
-        } else {
-            state.value.handles.getCornerNamedHandles()
-        }
+        val handles = if (cropShape is CropShape.FreeForm) state.value.handles.getAllNamedHandles()
+        else state.value.handles.getCornerNamedHandles()
 
         handles.forEach { (handle, handleType) ->
             val padding = touchPadding.value * density
@@ -277,7 +221,6 @@ internal class CropStateManager(
         }
 
         return null
-
     }
 
     private fun reset(bitmap: Bitmap) {
@@ -301,18 +244,25 @@ internal class CropStateManager(
         val imageWidth = bitmap.width.toFloat()
         val imageHeight = bitmap.height.toFloat()
 
+        // Add content padding equal to touchPadding so handles at edges
+        // always have their full touch area within the canvas bounds
+        val contentPadding = touchPadding.value * density
+        val availableWidth = canvasSize.width - contentPadding * 2
+        val availableHeight = canvasSize.height - contentPadding * 2
+
         val scaledSize = MathUtils.calculateScaledSize(
             srcWidth = imageWidth,
             srcHeight = imageHeight,
-            dstWidth = canvasSize.width,
-            dstHeight = canvasSize.height,
+            dstWidth = availableWidth,
+            dstHeight = availableHeight,
             contentScale = contentScale
         )
 
         val newBitmap = bitmap.scale(scaledSize.width.toInt(), scaledSize.height.toInt())
 
-        val offsetX = (canvasSize.width - scaledSize.width) / 2f
-        val offsetY = (canvasSize.height - scaledSize.height) / 2f
+        // Center within available space, then add padding offset
+        val offsetX = contentPadding + (availableWidth - scaledSize.width) / 2f
+        val offsetY = contentPadding + (availableHeight - scaledSize.height) / 2f
 
         val aspectRatio = when (cropShape) {
             is CropShape.FreeForm -> null

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropStateManager.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropStateManager.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.core.graphics.scale
 import com.tanishranjan.cropkit.CropShape
 import com.tanishranjan.cropkit.GridLinesVisibility
+import com.tanishranjan.cropkit.util.Extensions.coerceInOrderAgnostic
 import com.tanishranjan.cropkit.util.Extensions.isInsideRect
 import com.tanishranjan.cropkit.util.GestureUtils
 import com.tanishranjan.cropkit.util.MathUtils
@@ -144,10 +145,14 @@ internal class CropStateManager(
         val currentRect = state.value.cropRect
         val imageRect = state.value.imageRect
 
-        val newLeft = (currentRect.left + dragAmount.x)
-            .coerceIn(imageRect.left, imageRect.right - currentRect.width)
-        val newTop = (currentRect.top + dragAmount.y)
-            .coerceIn(imageRect.top, imageRect.bottom - currentRect.height)
+        val newLeft = (currentRect.left + dragAmount.x).coerceInOrderAgnostic(
+            imageRect.left,
+            imageRect.right - currentRect.width
+        )
+        val newTop = (currentRect.top + dragAmount.y).coerceInOrderAgnostic(
+            imageRect.top,
+            imageRect.bottom - currentRect.height
+        )
 
         val newRect = Rect(
             left = newLeft,

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropStateManager.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropStateManager.kt
@@ -31,13 +31,13 @@ internal class CropStateManager(
     private val handleRadius: Dp,
     private val touchPadding: Dp
 ) {
-
     private val _state = MutableStateFlow(CropState(bitmap))
     val state = _state.asStateFlow()
     private val coroutineScope = CoroutineScope(Dispatchers.Main)
     private var dragMode: DragMode = DragMode.None
     private val density get() = Resources.getSystem().displayMetrics.density
     private val handleRadiusPx: Float get() = handleRadius.value * density
+    private var dragOffset: Offset = Offset.Zero
 
     init {
         reset(bitmap)
@@ -85,7 +85,7 @@ internal class CropStateManager(
             else -> DragMode.None
         }
 
-        val dragOffset = when (val mode = dragMode) {
+        dragOffset = when (val mode = dragMode) {
             DragMode.None -> Offset.Zero
             DragMode.Move -> Offset(currentRect.left, currentRect.top)
             is DragMode.Handle -> GestureUtils.getHandleOffset(mode.handle, currentRect)
@@ -93,7 +93,6 @@ internal class CropStateManager(
 
         _state.update { cropState ->
             cropState.copy(
-                dragOffset = dragOffset,
                 isDragging = dragMode != DragMode.None,
                 gridlinesActive = if (gridLinesVisibility == GridLinesVisibility.ON_TOUCH) {
                     dragMode != DragMode.None
@@ -149,7 +148,7 @@ internal class CropStateManager(
         val imageRect = state.value.imageRect
 
         val correctedDragAmount = GestureUtils.getCorrectDragAmount(
-            dragOffset = state.value.dragOffset,
+            dragOffset = dragOffset,
             dragAmount = dragAmount
         )
 
@@ -170,8 +169,8 @@ internal class CropStateManager(
         )
 
         _state.update {
+            dragOffset = correctedDragAmount
             it.copy(
-                dragOffset = correctedDragAmount,
                 cropRect = newRect,
                 handles = GestureUtils.getNewHandleMeasures(newRect, handleRadiusPx)
             )
@@ -180,7 +179,7 @@ internal class CropStateManager(
 
     private fun moveDragHandle(activeHandle: DragHandle, dragAmount: Offset) {
         val correctedDragAmount = GestureUtils.getCorrectDragAmount(
-            dragOffset = state.value.dragOffset,
+            dragOffset = dragOffset,
             dragAmount = dragAmount
         )
 
@@ -193,8 +192,8 @@ internal class CropStateManager(
             aspectRatio = state.value.aspectRatio
         ).let { newRect ->
             _state.update {
+                dragOffset = correctedDragAmount
                 it.copy(
-                    dragOffset = correctedDragAmount,
                     cropRect = newRect,
                     handles = GestureUtils.getNewHandleMeasures(
                         newRect,

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/internal/DragMode.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/internal/DragMode.kt
@@ -1,9 +1,7 @@
 package com.tanishranjan.cropkit.internal
 
 internal sealed interface DragMode {
-
     data object None : DragMode
     data object Move : DragMode
     data class Handle(val handle: DragHandle) : DragMode
-
 }

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/util/Extensions.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/util/Extensions.kt
@@ -10,6 +10,4 @@ internal object Extensions {
         return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom
     }
 
-    fun CropShape.isSquareBounds(): Boolean = this == CropShape.SQUARE || this == CropShape.CIRCLE
-
 }

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/util/Extensions.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/util/Extensions.kt
@@ -2,7 +2,6 @@ package com.tanishranjan.cropkit.util
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
-import com.tanishranjan.cropkit.CropShape
 
 internal object Extensions {
 
@@ -10,4 +9,9 @@ internal object Extensions {
         return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom
     }
 
+    fun Float.coerceInOrderAgnostic(a: Float, b: Float): Float {
+        val min = minOf(a, b)
+        val max = maxOf(a, b)
+        return this.coerceIn(min, max)
+    }
 }

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/util/GestureUtils.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/util/GestureUtils.kt
@@ -4,8 +4,71 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import com.tanishranjan.cropkit.internal.DragHandle
 import com.tanishranjan.cropkit.HandlesRect
+import com.tanishranjan.cropkit.internal.DragHandle.*
+import com.tanishranjan.cropkit.util.Extensions.coerceInOrderAgnostic
+import kotlin.math.abs
 
 internal object GestureUtils {
+    /**
+     * Get the offset of a handle based on its type and the crop rectangle.
+     *
+     * @param activeHandle The handle type.
+     * @param cropRect The current crop rectangle.
+     * @return The offset of the handle.
+     */
+    fun getHandleOffset(
+        activeHandle: DragHandle,
+        cropRect: Rect
+    ): Offset =
+        when (activeHandle) {
+            TopLeft -> Offset(cropRect.left, cropRect.top)
+            TopRight -> Offset(cropRect.right, cropRect.top)
+            BottomLeft -> Offset(cropRect.left, cropRect.bottom)
+            BottomRight -> Offset(cropRect.right, cropRect.bottom)
+            Left -> Offset(cropRect.left, 0f)
+            Right -> Offset(cropRect.right, 0f)
+            Top -> Offset(0f, cropRect.top)
+            Bottom -> Offset(0f, cropRect.bottom)
+        }
+
+    /**
+     * Correct the drag amount based on the drag offset.
+     *
+     * @param dragOffset The current drag offset.
+     * @param dragAmount The original drag amount.
+     * @return The corrected drag amount.
+     */
+    fun getCorrectDragAmount(
+        dragOffset: Offset,
+        dragAmount: Offset
+    ): Offset = Offset(dragOffset.x + dragAmount.x, dragOffset.y + dragAmount.y)
+
+    /**
+     * Main entry point to calculate the new crop rectangle.
+     * Decides whether to use Free or Locked logic based on the [aspectRatio].
+     *
+     * @param activeHandle The handle that is currently being dragged.
+     * @param handleOffset The offset by which the handle is dragged.
+     * @param imageRect The current image rect.
+     * @param cropRect The current crop rect.
+     * @param minCropSize The minimum size of crop rectangle that should be maintained.
+     * @param aspectRatio The desired aspect ratio (width / height).
+     * @return The new crop rectangle if the drag is valid, null otherwise.
+     */
+    fun calculateNewCropRect(
+        activeHandle: DragHandle,
+        handleOffset: Offset,
+        imageRect: Rect,
+        cropRect: Rect,
+        minCropSize: Float,
+        aspectRatio: Float
+    ): Rect =
+        if (aspectRatio > 0f) getNewRectMeasuresLocked(
+            activeHandle, handleOffset, imageRect, cropRect, minCropSize, aspectRatio
+        )
+        else getNewRectMeasures(
+            activeHandle, handleOffset, imageRect, cropRect, minCropSize
+        )
 
     /**
      * Calculate the new crop rectangle based on the drag amount and the active handle.
@@ -15,7 +78,6 @@ internal object GestureUtils {
      * @param imageRect The current image rect.
      * @param cropRect The current crop rect.
      * @param minCropSize The minimum size of crop rectangle that should be maintained.
-     *
      * @return The new crop rectangle if the drag is valid, null otherwise.
      */
     fun getNewRectMeasures(
@@ -24,117 +86,211 @@ internal object GestureUtils {
         imageRect: Rect,
         cropRect: Rect,
         minCropSize: Float
-    ): Rect? {
-        return when (activeHandle) {
-
-            DragHandle.TopLeft -> {
-                val newOffset = cropRect.topLeft + dragAmount
-                if (newOffset.x !in imageRect.left..cropRect.right - minCropSize
-                    || newOffset.y !in imageRect.top..cropRect.bottom - minCropSize
-                ) return null
-                Rect(
-                    left = newOffset.x,
-                    top = newOffset.y,
-                    right = cropRect.right,
-                    bottom = cropRect.bottom
-                )
-            }
-
-            DragHandle.TopRight -> {
-                val newOffset = cropRect.topRight + dragAmount
-                if (newOffset.x !in cropRect.left + minCropSize..imageRect.right
-                    || newOffset.y !in imageRect.top..cropRect.bottom - minCropSize
-                ) return cropRect
-                Rect(
-                    left = cropRect.left,
-                    top = newOffset.y,
-                    right = newOffset.x,
-                    bottom = cropRect.bottom
-                )
-            }
-
-            DragHandle.BottomLeft -> {
-                val newOffset = cropRect.bottomLeft + dragAmount
-                if (newOffset.x !in imageRect.left..cropRect.right - minCropSize
-                    || newOffset.y !in cropRect.top + minCropSize..imageRect.bottom
-                ) return cropRect
-                Rect(
-                    left = newOffset.x,
-                    top = cropRect.top,
-                    right = cropRect.right,
-                    bottom = newOffset.y
-                )
-            }
-
-            DragHandle.BottomRight -> {
-                val newOffset = cropRect.bottomRight + dragAmount
-                if (newOffset.x !in cropRect.left + minCropSize..imageRect.right
-                    || newOffset.y !in cropRect.top + minCropSize..imageRect.bottom
-                ) return cropRect
-                Rect(
-                    left = cropRect.left,
-                    top = cropRect.top,
-                    right = newOffset.x,
-                    bottom = newOffset.y
-                )
-            }
-
-            DragHandle.Top -> {
-                val newOffset = cropRect.topLeft + dragAmount
-                val newTop = newOffset.y.coerceIn(
-                    imageRect.top,
-                    cropRect.bottom - minCropSize
-                )
-                Rect(
-                    left = cropRect.left,
-                    top = newTop,
-                    right = cropRect.right,
-                    bottom = cropRect.bottom
-                )
-            }
-
-            DragHandle.Bottom -> {
-                val newOffset = cropRect.bottomLeft + dragAmount
-                val newBottom = newOffset.y.coerceIn(
-                    cropRect.top + minCropSize,
-                    imageRect.bottom
-                )
-                Rect(
-                    left = cropRect.left,
-                    top = cropRect.top,
-                    right = cropRect.right,
-                    bottom = newBottom
-                )
-            }
-
-            DragHandle.Left -> {
-                val newOffset = cropRect.bottomLeft + dragAmount
-                val newLeft = newOffset.x.coerceIn(
-                    imageRect.left,
-                    cropRect.right - minCropSize
-                )
-                Rect(
-                    left = newLeft,
-                    top = cropRect.top,
-                    right = cropRect.right,
-                    bottom = cropRect.bottom
-                )
-            }
-
-            DragHandle.Right -> {
-                val newOffset = cropRect.topRight + dragAmount
-                val newRight = newOffset.x.coerceIn(
-                    cropRect.left + minCropSize,
-                    imageRect.right
-                )
-                Rect(
-                    left = cropRect.left,
-                    top = cropRect.top,
-                    right = newRight,
-                    bottom = cropRect.bottom
-                )
-            }
+    ): Rect = when (activeHandle) {
+        TopLeft -> {
+            val newLeft = dragAmount.x.coerceInOrderAgnostic(
+                imageRect.left,
+                cropRect.right - minCropSize
+            )
+            val newTop = dragAmount.y.coerceInOrderAgnostic(
+                imageRect.top,
+                cropRect.bottom - minCropSize
+            )
+            Rect(
+                left = newLeft,
+                top = newTop,
+                right = cropRect.right,
+                bottom = cropRect.bottom
+            )
         }
+
+        TopRight -> {
+            val newRight = dragAmount.x.coerceInOrderAgnostic(
+                cropRect.left + minCropSize,
+                imageRect.right
+            )
+            val newTop = dragAmount.y.coerceInOrderAgnostic(
+                imageRect.top,
+                cropRect.bottom - minCropSize
+            )
+            Rect(
+                left = cropRect.left,
+                top = newTop,
+                right = newRight,
+                bottom = cropRect.bottom
+            )
+        }
+
+        BottomLeft -> {
+            val newLeft = dragAmount.x.coerceInOrderAgnostic(
+                imageRect.left,
+                cropRect.right - minCropSize
+            )
+            val newBottom = dragAmount.y.coerceInOrderAgnostic(
+                cropRect.top + minCropSize,
+                imageRect.bottom
+            )
+            Rect(
+                left = newLeft,
+                top = cropRect.top,
+                right = cropRect.right,
+                bottom = newBottom
+            )
+        }
+
+        BottomRight -> {
+            val newRight = dragAmount.x.coerceInOrderAgnostic(
+                cropRect.left + minCropSize,
+                imageRect.right
+            )
+            val newBottom = dragAmount.y.coerceInOrderAgnostic(
+                cropRect.top + minCropSize,
+                imageRect.bottom
+            )
+            Rect(
+                left = cropRect.left,
+                top = cropRect.top,
+                right = newRight,
+                bottom = newBottom
+            )
+        }
+
+        Top -> {
+            val newTop = dragAmount.y.coerceInOrderAgnostic(
+                imageRect.top,
+                cropRect.bottom - minCropSize
+            )
+            Rect(
+                left = cropRect.left,
+                top = newTop,
+                right = cropRect.right,
+                bottom = cropRect.bottom
+            )
+        }
+
+        Bottom -> {
+            val newBottom = dragAmount.y.coerceInOrderAgnostic(
+                cropRect.top + minCropSize,
+                imageRect.bottom
+            )
+            Rect(
+                left = cropRect.left,
+                top = cropRect.top,
+                right = cropRect.right,
+                bottom = newBottom
+            )
+        }
+
+        Left -> {
+            val newLeft = dragAmount.x.coerceInOrderAgnostic(
+                imageRect.left,
+                cropRect.right - minCropSize
+            )
+            Rect(
+                left = newLeft,
+                top = cropRect.top,
+                right = cropRect.right,
+                bottom = cropRect.bottom
+            )
+        }
+
+        Right -> {
+            val newRight = dragAmount.x.coerceInOrderAgnostic(
+                cropRect.left + minCropSize,
+                imageRect.right
+            )
+            Rect(
+                left = cropRect.left,
+                top = cropRect.top,
+                right = newRight,
+                bottom = cropRect.bottom
+            )
+        }
+    }
+
+    /**
+     * Calculates the new crop rectangle with locked Aspect Ratio.
+     * It projects the user's gesture onto the aspect ratio diagonal, ensuring the
+     * rectangle grows/shrinks naturally while staying within image bounds.
+     *
+     * @param activeHandle The handle that is currently being dragged.
+     * @param handleOffset The offset by which the handle is dragged.
+     * @param imageRect The current image rect.
+     * @param cropRect The current crop rect.
+     * @param minCropSize The minimum size of crop rectangle that should be maintained.
+     * @param aspectRatio The desired aspect ratio (width / height).
+     * @return The new crop rectangle if the drag is valid, null otherwise.
+     */
+    fun getNewRectMeasuresLocked(
+        activeHandle: DragHandle,
+        handleOffset: Offset,
+        imageRect: Rect,
+        cropRect: Rect,
+        minCropSize: Float,
+        aspectRatio: Float
+    ): Rect {
+        val pivot = when (activeHandle) {
+            TopLeft -> Offset(cropRect.right, cropRect.bottom)
+            TopRight -> Offset(cropRect.left, cropRect.bottom)
+            BottomLeft -> Offset(cropRect.right, cropRect.top)
+            BottomRight -> Offset(cropRect.left, cropRect.top)
+            else -> return cropRect
+        }
+
+        // Calculate raw distances from the pivot to the target finger position
+        val distanceX = abs(handleOffset.x - pivot.x)
+        val distanceY = abs(handleOffset.y - pivot.y)
+
+        // Generate Candidates (Projections)
+        val widthBasedOnX = distanceX.coerceAtLeast(minCropSize)
+        val heightDerivedFromX = widthBasedOnX / aspectRatio
+
+        val heightBasedOnY = distanceY.coerceAtLeast(minCropSize)
+        val widthDerivedFromY = heightBasedOnY * aspectRatio
+
+        // We pick the candidate that produces the smallest rectangle
+        var finalWidth = if (widthBasedOnX < widthDerivedFromY)
+            widthBasedOnX else widthDerivedFromY
+        var finalHeight = if (widthBasedOnX < widthDerivedFromY)
+            heightDerivedFromX else heightBasedOnY
+
+
+        // Bounds Constraint
+        // Determine the direction of growth relative to the pivot (-1 for Left/Up, 1 for Right/Down)
+        val directionX = if (handleOffset.x < pivot.x) -1f else 1f
+        val directionY = if (handleOffset.y < pivot.y) -1f else 1f
+
+        // Check Horizontal Bounds
+        val proposedLeft = if (directionX < 0) pivot.x - finalWidth else pivot.x
+        val proposedRight = if (directionX < 0) pivot.x else pivot.x + finalWidth
+
+        if (proposedLeft < imageRect.left || proposedRight > imageRect.right) {
+            val maxWidthAvailable = if (directionX < 0) (pivot.x - imageRect.left)
+            else (imageRect.right - pivot.x)
+
+            finalWidth = maxWidthAvailable
+            finalHeight = finalWidth / aspectRatio
+        }
+
+        // Check Vertical Bounds
+        val proposedTop = if (directionY < 0) pivot.y - finalHeight else pivot.y
+        val proposedBottom = if (directionY < 0) pivot.y else pivot.y + finalHeight
+
+        if (proposedTop < imageRect.top || proposedBottom > imageRect.bottom) {
+            val maxHeightAvailable = if (directionY < 0) (pivot.y - imageRect.top)
+            else (imageRect.bottom - pivot.y)
+
+            finalHeight = maxHeightAvailable
+            finalWidth = finalHeight * aspectRatio
+        }
+
+
+        return Rect(
+            left = if (directionX < 0) pivot.x - finalWidth else pivot.x,
+            top = if (directionY < 0) pivot.y - finalHeight else pivot.y,
+            right = if (directionX < 0) pivot.x else pivot.x + finalWidth,
+            bottom = if (directionY < 0) pivot.y else pivot.y + finalHeight
+        )
     }
 
     /**
@@ -233,5 +389,4 @@ internal object GestureUtils {
         )
 
     }
-
 }

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/util/GestureUtils.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/util/GestureUtils.kt
@@ -237,15 +237,40 @@ internal object GestureUtils {
             else -> return cropRect
         }
 
-        // Calculate raw distances from the pivot to the target finger position
-        val distanceX = abs(handleOffset.x - pivot.x)
-        val distanceY = abs(handleOffset.y - pivot.y)
+        // Pre-calculate minimum limits based on the Aspect Ratio
+        val minWidth: Float
+        val minHeight: Float
+
+        if (aspectRatio >= 1f) {
+            minHeight = minCropSize
+            minWidth = minHeight * aspectRatio
+        } else {
+            minWidth = minCropSize
+            minHeight = minWidth / aspectRatio
+        }
+
+        // Constrain the Handle Offset
+        val constrainedX = when (activeHandle) {
+            TopLeft, BottomLeft -> handleOffset.x.coerceAtMost(pivot.x - minWidth)
+            TopRight, BottomRight -> handleOffset.x.coerceAtLeast(pivot.x + minWidth)
+            else -> handleOffset.x
+        }
+
+        val constrainedY = when (activeHandle) {
+            TopLeft, TopRight -> handleOffset.y.coerceAtMost(pivot.y - minHeight)
+            BottomLeft, BottomRight -> handleOffset.y.coerceAtLeast(pivot.y + minHeight)
+            else -> handleOffset.y
+        }
+
+        // Calculate distances using the CONSTRAINED position
+        val distanceX = abs(constrainedX - pivot.x)
+        val distanceY = abs(constrainedY - pivot.y)
 
         // Generate Candidates (Projections)
-        val widthBasedOnX = distanceX.coerceAtLeast(minCropSize)
+        val widthBasedOnX = distanceX.coerceAtLeast(minWidth)
         val heightDerivedFromX = widthBasedOnX / aspectRatio
 
-        val heightBasedOnY = distanceY.coerceAtLeast(minCropSize)
+        val heightBasedOnY = distanceY.coerceAtLeast(minHeight)
         val widthDerivedFromY = heightBasedOnY * aspectRatio
 
         // We pick the candidate that produces the smallest rectangle
@@ -254,19 +279,19 @@ internal object GestureUtils {
         var finalHeight = if (widthBasedOnX < widthDerivedFromY)
             heightDerivedFromX else heightBasedOnY
 
-
         // Bounds Constraint
         // Determine the direction of growth relative to the pivot (-1 for Left/Up, 1 for Right/Down)
-        val directionX = if (handleOffset.x < pivot.x) -1f else 1f
-        val directionY = if (handleOffset.y < pivot.y) -1f else 1f
+        val directionX = if (activeHandle == TopRight || activeHandle == BottomRight) 1f else -1f
+        val directionY = if (activeHandle == BottomLeft || activeHandle == BottomRight) 1f else -1f
 
         // Check Horizontal Bounds
         val proposedLeft = if (directionX < 0) pivot.x - finalWidth else pivot.x
         val proposedRight = if (directionX < 0) pivot.x else pivot.x + finalWidth
 
         if (proposedLeft < imageRect.left || proposedRight > imageRect.right) {
-            val maxWidthAvailable = if (directionX < 0) (pivot.x - imageRect.left)
-            else (imageRect.right - pivot.x)
+            val maxWidthAvailable =
+                if (directionX < 0) (pivot.x - imageRect.left)
+                else (imageRect.right - pivot.x)
 
             finalWidth = maxWidthAvailable
             finalHeight = finalWidth / aspectRatio
@@ -283,7 +308,6 @@ internal object GestureUtils {
             finalHeight = maxHeightAvailable
             finalWidth = finalHeight * aspectRatio
         }
-
 
         return Rect(
             left = if (directionX < 0) pivot.x - finalWidth else pivot.x,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,13 @@
 [versions]
-agp = "8.9.1"
+agp = "8.10.1"
 kotlin = "2.1.10"
-coreKtx = "1.15.0"
+coreKtx = "1.16.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
-lifecycleRuntimeKtx = "2.8.7"
+lifecycleRuntimeKtx = "2.9.1"
 activityCompose = "1.10.1"
-composeBom = "2025.03.01"
+composeBom = "2025.06.01"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }


### PR DESCRIPTION
## Description

This PR significantly improves the UX of the cropping tool by overhauling the gesture calculation logic. Previously, resizing with a locked aspect ratio could feel "jumpy" or unresponsive. I have implemented a vector projection approach that ensures the crop rectangle follows the user's finger naturally while respecting the aspect ratio constraints.

Additionally, this PR addresses touch handling issues at the edges of the image (related to PR #9) by adding content padding to the canvas, ensuring handles are always clickable.

**Key Changes:**
- Implemented `getNewRectMeasuresLocked` using vector projection for precise, locked resizing.
- Added `calculateNewCropRect` as a unified entry point to cleanly switch between free-form and locked logic.
- Refactored `CropStateManager` to track `dragOffset` for smoother updates.
- Increased `touchPadding` to `20.dp` and updated canvas initialization to include content padding.

Fixes #9

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I have performed manual testing on an Android phone to verify the gesture behavior.

- [x] **Locked Aspect Ratio Test:** Verified that dragging corners with a fixed ratio (e.g., 16:9, 1:1) resizes smoothly without jumping, even when dragging far from the pivot point, and going out then inside the bounds of the image.
- [x] **Free Crop Test:** Verified that standard cropping (aspect ratio 0f) works robustly and respects the new clamping logic.
- [x] **Edge Touch Test:** Moved the crop selection to the absolute edges of the image and verified that corner handles remain fully interactive and easy to grab.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules