### PR TITLE
Perf/suspend crop transforms

### DIFF
--- a/app/src/main/java/com/tanishranjan/cropkit_demo/MainActivity.kt
+++ b/app/src/main/java/com/tanishranjan/cropkit_demo/MainActivity.kt
@@ -41,6 +41,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -54,6 +55,7 @@ import com.tanishranjan.cropkit.GridLinesType
 import com.tanishranjan.cropkit.ImageCropper
 import com.tanishranjan.cropkit.rememberCropController
 import com.tanishranjan.cropkit_demo.ui.theme.CropKitTheme
+import kotlinx.coroutines.launch
 import java.io.File
 import java.io.FileOutputStream
 import java.io.OutputStream
@@ -79,6 +81,7 @@ class MainActivity : ComponentActivity() {
                     )
                 }
 
+                val coroutineScope = rememberCoroutineScope()
                 val context = LocalContext.current
                 val imagePicker = rememberLauncherForActivityResult(
                     ActivityResultContracts.PickVisualMedia()
@@ -96,8 +99,10 @@ class MainActivity : ComponentActivity() {
                             actions = {
                                 IconButton(
                                     onClick = {
-                                        cropController?.crop()?.let {
-                                            saveImage(context, it)
+                                        cropController?.let { controller ->
+                                            coroutineScope.launch {
+                                                saveImage(context, controller.crop())
+                                            }
                                         }
                                     }
                                 ) {
@@ -207,7 +212,7 @@ class MainActivity : ComponentActivity() {
 
                                         IconButton(
                                             onClick = {
-                                                cropController.rotateAntiClockwise()
+                                                coroutineScope.launch { cropController.rotateAntiClockwise() }
                                             }
                                         ) {
                                             Icon(
@@ -218,7 +223,7 @@ class MainActivity : ComponentActivity() {
 
                                         IconButton(
                                             onClick = {
-                                                cropController.rotateClockwise()
+                                                coroutineScope.launch { cropController.rotateClockwise() }
                                             }
                                         ) {
                                             Icon(
@@ -229,7 +234,7 @@ class MainActivity : ComponentActivity() {
 
                                         IconButton(
                                             onClick = {
-                                                cropController.flipVertically()
+                                                coroutineScope.launch { cropController.flipVertically() }
                                             }
                                         ) {
                                             Icon(
@@ -240,7 +245,7 @@ class MainActivity : ComponentActivity() {
 
                                         IconButton(
                                             onClick = {
-                                                cropController.flipHorizontally()
+                                                coroutineScope.launch { cropController.flipHorizontally() }
                                             }
                                         ) {
                                             Icon(

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/CropController.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/CropController.kt
@@ -34,27 +34,27 @@ class CropController(
     /**
      * Returns the cropped bitmap.
      */
-    fun crop(): Bitmap = stateManager.crop()
+    suspend fun crop(): Bitmap = stateManager.crop()
 
     /**
      * Rotates the bitmap clockwise in the ImageCropper.
      */
-    fun rotateClockwise() = stateManager.rotateClockwise()
+    suspend fun rotateClockwise() = stateManager.rotateClockwise()
 
     /**
      * Rotates the bitmap anti-clockwise in the ImageCropper.
      */
-    fun rotateAntiClockwise() = stateManager.rotateAntiClockwise()
+    suspend fun rotateAntiClockwise() = stateManager.rotateAntiClockwise()
 
     /**
      * Flips the bitmap horizontally in the ImageCropper.
      */
-    fun flipHorizontally() = stateManager.flipHorizontally()
+    suspend fun flipHorizontally() = stateManager.flipHorizontally()
 
     /**
      * Flips the bitmap vertically in the ImageCropper.
      */
-    fun flipVertically() = stateManager.flipVertically()
+    suspend fun flipVertically() = stateManager.flipVertically()
 
     internal fun onStateChange(action: CropStateChangeActions) {
         when (action) {

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropStateManager.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropStateManager.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlin.math.abs
 
 internal class CropStateManager(
@@ -48,7 +49,7 @@ internal class CropStateManager(
         setState(canvasSize, state.value.bitmap)
     }
 
-    fun crop(): Bitmap {
+    suspend fun crop(): Bitmap = withContext(Dispatchers.Default) {
         val state = state.value
         val bitmap = state.bitmap
         val imageRect = state.imageRect
@@ -67,12 +68,11 @@ internal class CropStateManager(
         val width = cropWidth.coerceIn(0, bitmap.width - x)
         val height = cropHeight.coerceIn(0, bitmap.height - y)
 
-        return Bitmap.createBitmap(
+        return@withContext Bitmap.createBitmap(
             bitmap,
             x, y,
             width, height
         )
-
     }
 
     fun onDragStart(offset: Offset) {
@@ -120,23 +120,28 @@ internal class CropStateManager(
         }
     }
 
-    fun rotateClockwise() = transformBitmap { matrix -> matrix.postRotate(90f) }
+    suspend fun rotateClockwise() = transformBitmap { matrix -> matrix.postRotate(90f) }
 
-    fun rotateAntiClockwise() = transformBitmap { matrix -> matrix.postRotate(-90f) }
+    suspend fun rotateAntiClockwise() = transformBitmap { matrix -> matrix.postRotate(-90f) }
 
-    fun flipHorizontally() = transformBitmap { matrix -> matrix.postScale(-1f, 1f) }
+    suspend fun flipHorizontally() = transformBitmap { matrix -> matrix.postScale(-1f, 1f) }
 
-    fun flipVertically() = transformBitmap { matrix -> matrix.postScale(1f, -1f) }
+    suspend fun flipVertically() = transformBitmap { matrix -> matrix.postScale(1f, -1f) }
 
-    private fun transformBitmap(transformation: (Matrix) -> Unit) {
-        val bitmap = state.value.bitmap
+    private suspend fun transformBitmap(transformation: (Matrix) -> Unit) {
+        val oldBitmap = state.value.bitmap
         val matrix = Matrix().apply(transformation)
-        val newBitmap = Bitmap.createBitmap(
-            bitmap, 0, 0,
-            bitmap.width, bitmap.height,
-            matrix, true
-        )
+        val newBitmap = withContext(Dispatchers.Default) {
+            Bitmap.createBitmap(
+                oldBitmap, 0, 0,
+                oldBitmap.width, oldBitmap.height,
+                matrix, true
+            )
+        }
         reset(newBitmap)
+        if (newBitmap !== oldBitmap) {
+            oldBitmap.recycle()
+        }
     }
 
     private fun moveCropRect(dragAmount: Offset) {


### PR DESCRIPTION
@Tanish-Ranjan I've created a series of branches with improvements that were applied to my inlined library version.


This particular PR is a breaking change when it comes to the library API and would require a major number bump.
## Description

`crop()`, `rotateClockwise()`, `rotateAntiClockwise()`, `flipHorizontally()` and `flipVertically()` did bitmap allocation/transform work synchronously on the caller's thread. They're now `suspend` functions that run on `Dispatchers.Default`, and the bitmap being replaced by a rotate/flip is recycled so repeated transforms don't pile up native memory. The demo app is updated in the same branch to call these from a `rememberCoroutineScope()`.

Branch: `perf/suspend-crop-transforms` (2 commits)

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] `./gradlew :cropkit:compileDebugKotlin :app:compileDebugKotlin` succeeds
- [ ] Manual testing in the demo app (crop, rotate, flip)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
