### PR TITLE
Tighten internal API surface: internal HandlesRect, sealed CropStateC…

### DIFF
--- a/cropkit/src/main/java/com/tanishranjan/cropkit/HandlesRect.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/HandlesRect.kt
@@ -15,7 +15,7 @@ import com.tanishranjan.cropkit.internal.DragHandle
  * @param right The right handle.
  * @param left The left handle.
  */
-data class HandlesRect(
+internal data class HandlesRect(
     val topLeft: Rect = Rect.Zero,
     val topRight: Rect = Rect.Zero,
     val bottomLeft: Rect = Rect.Zero,
@@ -26,25 +26,16 @@ data class HandlesRect(
     val left: Rect = Rect.Zero
 ) {
 
-    /**
-     * Returns the corner handles of the crop rectangle.
-     */
-    fun getCornerHandles(): List<Rect> {
-        return listOf(topLeft, topRight, bottomLeft, bottomRight)
+    val cornerHandles: List<Rect> by lazy {
+        listOf(topLeft, topRight, bottomLeft, bottomRight)
     }
 
-    /**
-     * Returns corner and side handles of the crop rectangle.
-     */
-    fun getAllHandles(): List<Rect> {
-        return listOf(topLeft, topRight, bottomLeft, bottomRight, top, bottom, right, left)
+    val allHandles: List<Rect> by lazy {
+        listOf(topLeft, topRight, bottomLeft, bottomRight, top, bottom, right, left)
     }
 
-    /**
-     * Returns the corner handles of the crop rectangle along with their names.
-     */
-    internal fun getCornerNamedHandles(): List<Pair<Rect, DragHandle>> {
-        return listOf(
+    val cornerNamedHandles: List<Pair<Rect, DragHandle>> by lazy {
+        listOf(
             topLeft to DragHandle.TopLeft,
             topRight to DragHandle.TopRight,
             bottomLeft to DragHandle.BottomLeft,
@@ -52,11 +43,8 @@ data class HandlesRect(
         )
     }
 
-    /**
-     * Returns corner and side handles of the crop rectangle along with their names.
-     */
-    internal fun getAllNamedHandles(): List<Pair<Rect, DragHandle>> {
-        return listOf(
+    val allNamedHandles: List<Pair<Rect, DragHandle>> by lazy {
+        listOf(
             topLeft to DragHandle.TopLeft,
             topRight to DragHandle.TopRight,
             bottomLeft to DragHandle.BottomLeft,

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/ImageCropper.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/ImageCropper.kt
@@ -190,9 +190,9 @@ fun ImageCropper(
 
                 // Draw edge handles only for free form cropping only
                 val handles = if (cropOptions.cropShape is CropShape.FreeForm) {
-                    state.handles.getAllHandles()
+                    state.handles.allHandles
                 } else {
-                    state.handles.getCornerHandles()
+                    state.handles.cornerHandles
                 }
 
                 handles.forEach { handle ->

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropStateChangeActions.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropStateChangeActions.kt
@@ -3,7 +3,7 @@ package com.tanishranjan.cropkit.internal
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 
-interface CropStateChangeActions {
+sealed interface CropStateChangeActions {
 
     data class DragStart(val offset: Offset) : CropStateChangeActions
     data object DragEnd : CropStateChangeActions

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropStateManager.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropStateManager.kt
@@ -259,9 +259,9 @@ internal class CropStateManager(
     private fun findActiveHandle(offset: Offset): DragHandle? {
         // TODO: Allow cropping with all handles in locked aspect ratios
         val handles = if (cropShape is CropShape.FreeForm) {
-            state.value.handles.getAllNamedHandles()
+            state.value.handles.allNamedHandles
         } else {
-            state.value.handles.getCornerNamedHandles()
+            state.value.handles.cornerNamedHandles
         }
 
         handles.forEach { (handle, handleType) ->


### PR DESCRIPTION
@Tanish-Ranjan I've created a series of branches with improvements that were applied to my inlined library version.

## Description

Neither `HandlesRect` nor `CropStateChangeActions` is meant to be used outside the library. `HandlesRect` is now `internal`, and its getter methods (`getCornerHandles()`, `getAllHandles()`, `getCornerNamedHandles()`, `getAllNamedHandles()`) are replaced with lazily computed properties (`cornerHandles`, `allHandles`, `cornerNamedHandles`, `allNamedHandles`). `CropStateChangeActions` becomes a sealed interface so its variants are exhaustively checkable.

Branch: `refactor/internal-api-visibility` (1 commit)

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] `./gradlew :cropkit:compileDebugKotlin :app:compileDebugKotlin` succeeds

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
