### PR TITLE
Auto-dispose CropController's coroutine scope via Closeable

### DIFF
--- a/cropkit/src/main/java/com/tanishranjan/cropkit/CropController.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/CropController.kt
@@ -1,8 +1,9 @@
 package com.tanishranjan.cropkit
 
 import android.graphics.Bitmap
-import com.tanishranjan.cropkit.internal.CropStateManager
 import com.tanishranjan.cropkit.internal.CropStateChangeActions
+import com.tanishranjan.cropkit.internal.CropStateManager
+import java.io.Closeable
 
 /**
  * CropController is the main class that is used to interact with the [ImageCropper].
@@ -15,7 +16,7 @@ class CropController(
     bitmap: Bitmap,
     val cropOptions: CropOptions,
     val cropColors: CropColors
-) {
+) : Closeable {
 
     private val stateManager: CropStateManager = CropStateManager(
         bitmap = bitmap,
@@ -30,6 +31,10 @@ class CropController(
      * State flow of the ImageCropper current state.
      */
     internal val state = stateManager.state
+
+    override fun close() {
+        stateManager.close()
+    }
 
     /**
      * Returns the cropped bitmap.

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/ImageCropper.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/ImageCropper.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -35,8 +36,14 @@ fun rememberCropController(
     bitmap: Bitmap,
     cropOptions: CropOptions = CropDefaults.cropOptions(),
     cropColors: CropColors = CropDefaults.cropColors()
-): CropController = remember(bitmap, cropOptions, cropColors) {
-    CropController(bitmap, cropOptions, cropColors)
+): CropController {
+    val controller = remember(bitmap, cropOptions, cropColors) {
+        CropController(bitmap, cropOptions, cropColors)
+    }
+    DisposableEffect(controller) {
+        onDispose { controller.close() }
+    }
+    return controller
 }
 
 /**

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropStateManager.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropStateManager.kt
@@ -18,10 +18,12 @@ import com.tanishranjan.cropkit.util.GestureUtils
 import com.tanishranjan.cropkit.util.MathUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.io.Closeable
 import kotlin.math.abs
 
 internal class CropStateManager(
@@ -31,7 +33,7 @@ internal class CropStateManager(
     private val gridLinesVisibility: GridLinesVisibility,
     private val handleRadius: Dp,
     private val touchPadding: Dp
-) {
+) : Closeable {
 
     private val _state = MutableStateFlow(CropState(bitmap))
     val state = _state.asStateFlow()
@@ -42,6 +44,10 @@ internal class CropStateManager(
 
     init {
         reset(bitmap)
+    }
+
+    override fun close() {
+        coroutineScope.cancel()
     }
 
     fun updateCanvasSize(canvasSize: Size) {


### PR DESCRIPTION
@Tanish-Ranjan I've created a series of branches with improvements that were applied to my inlined library version.

## Description

`CropStateManager` ran a long-lived `CoroutineScope(Dispatchers.Main)` with nothing to ever cancel it. `CropController`/`CropStateManager` now implement `Closeable`, and `rememberCropController` closes the controller in a `DisposableEffect` so the scope is cancelled automatically when it leaves composition.

Branch: `feat/auto-dispose-crop-controller` (1 commit)

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] `./gradlew :cropkit:compileDebugKotlin :app:compileDebugKotlin` succeeds
- [ ] Manual testing: navigate away from the cropper mid-use and confirm no leaked coroutines

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
