### PR TITLE
Support aspect-ratio-locked resizing from side handles

### DIFF
--- a/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropStateManager.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropStateManager.kt
@@ -181,7 +181,8 @@ internal class CropStateManager(
             dragAmount = adjustedDragAmount,
             imageRect = state.value.imageRect,
             cropRect = state.value.cropRect,
-            minCropSize = MIN_CROP_SIZE
+            minCropSize = MIN_CROP_SIZE,
+            aspectRatio = state.value.aspectRatio
         )?.let { newRect ->
             _state.update {
                 it.copy(
@@ -251,18 +252,14 @@ internal class CropStateManager(
                 }
             }
 
-            else -> Offset.Zero
+            DragHandle.Top, DragHandle.Bottom,
+            DragHandle.Left, DragHandle.Right -> dragAmount
         }
 
     }
 
     private fun findActiveHandle(offset: Offset): DragHandle? {
-        // TODO: Allow cropping with all handles in locked aspect ratios
-        val handles = if (cropShape is CropShape.FreeForm) {
-            state.value.handles.getAllNamedHandles()
-        } else {
-            state.value.handles.getCornerNamedHandles()
-        }
+        val handles = state.value.handles.getAllNamedHandles()
 
         handles.forEach { (handle, handleType) ->
             val padding = touchPadding.value * density

--- a/cropkit/src/main/java/com/tanishranjan/cropkit/util/GestureUtils.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/util/GestureUtils.kt
@@ -2,8 +2,8 @@ package com.tanishranjan.cropkit.util
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
-import com.tanishranjan.cropkit.internal.DragHandle
 import com.tanishranjan.cropkit.HandlesRect
+import com.tanishranjan.cropkit.internal.DragHandle
 
 internal object GestureUtils {
 
@@ -15,6 +15,7 @@ internal object GestureUtils {
      * @param imageRect The current image rect.
      * @param cropRect The current crop rect.
      * @param minCropSize The minimum size of crop rectangle that should be maintained.
+     * @param aspectRatio The aspect ratio (width/height) to maintain. 0 means free-form.
      *
      * @return The new crop rectangle if the drag is valid, null otherwise.
      */
@@ -23,116 +24,178 @@ internal object GestureUtils {
         dragAmount: Offset,
         imageRect: Rect,
         cropRect: Rect,
-        minCropSize: Float
+        minCropSize: Float,
+        aspectRatio: Float = 0f
     ): Rect? {
         return when (activeHandle) {
-
             DragHandle.TopLeft -> {
                 val newOffset = cropRect.topLeft + dragAmount
-                if (newOffset.x !in imageRect.left..cropRect.right - minCropSize
-                    || newOffset.y !in imageRect.top..cropRect.bottom - minCropSize
-                ) return null
-                Rect(
+                val isXWithinBounds = newOffset.x in imageRect.left..cropRect.right - minCropSize
+                val isYWithinBounds = newOffset.y in imageRect.top..cropRect.bottom - minCropSize
+                if (isXWithinBounds && isYWithinBounds) Rect(
                     left = newOffset.x,
                     top = newOffset.y,
                     right = cropRect.right,
                     bottom = cropRect.bottom
-                )
+                ) else cropRect
+
             }
 
             DragHandle.TopRight -> {
                 val newOffset = cropRect.topRight + dragAmount
-                if (newOffset.x !in cropRect.left + minCropSize..imageRect.right
-                    || newOffset.y !in imageRect.top..cropRect.bottom - minCropSize
-                ) return cropRect
-                Rect(
+                val isXWithinBounds = newOffset.x in cropRect.left + minCropSize..imageRect.right
+                val isYWithinBounds = newOffset.y in imageRect.top..cropRect.bottom - minCropSize
+                if (isXWithinBounds && isYWithinBounds) Rect(
                     left = cropRect.left,
                     top = newOffset.y,
                     right = newOffset.x,
                     bottom = cropRect.bottom
                 )
+                else return cropRect
+
             }
 
             DragHandle.BottomLeft -> {
                 val newOffset = cropRect.bottomLeft + dragAmount
-                if (newOffset.x !in imageRect.left..cropRect.right - minCropSize
-                    || newOffset.y !in cropRect.top + minCropSize..imageRect.bottom
-                ) return cropRect
-                Rect(
+                val isXWithinBounds = newOffset.x in imageRect.left..cropRect.right - minCropSize
+                val isYWithinBounds = newOffset.y in cropRect.top + minCropSize..imageRect.bottom
+                if (isXWithinBounds && isYWithinBounds) Rect(
                     left = newOffset.x,
                     top = cropRect.top,
                     right = cropRect.right,
                     bottom = newOffset.y
                 )
+                else cropRect
+
             }
 
             DragHandle.BottomRight -> {
                 val newOffset = cropRect.bottomRight + dragAmount
-                if (newOffset.x !in cropRect.left + minCropSize..imageRect.right
-                    || newOffset.y !in cropRect.top + minCropSize..imageRect.bottom
-                ) return cropRect
-                Rect(
+                val isXWithinBounds = newOffset.x in cropRect.left + minCropSize..imageRect.right
+                val isYWithinBounds = newOffset.y in cropRect.top + minCropSize..imageRect.bottom
+                if (isXWithinBounds && isYWithinBounds) Rect(
                     left = cropRect.left,
                     top = cropRect.top,
                     right = newOffset.x,
                     bottom = newOffset.y
                 )
+                else cropRect
             }
 
             DragHandle.Top -> {
-                val newOffset = cropRect.topLeft + dragAmount
-                val newTop = newOffset.y.coerceIn(
-                    imageRect.top,
-                    cropRect.bottom - minCropSize
-                )
-                Rect(
-                    left = cropRect.left,
-                    top = newTop,
-                    right = cropRect.right,
-                    bottom = cropRect.bottom
-                )
+                if (aspectRatio > 0f) {
+                    val newTop = (cropRect.top + dragAmount.y).coerceIn(
+                        imageRect.top, cropRect.bottom - minCropSize
+                    )
+                    val newHeight = cropRect.bottom - newTop
+                    val newWidth = newHeight * aspectRatio
+                    val centerX = cropRect.center.x
+                    val newLeft = centerX - newWidth / 2
+                    val newRight = centerX + newWidth / 2
+                    if (newWidth >= minCropSize && newLeft >= imageRect.left && newRight <= imageRect.right) {
+                        Rect(
+                            left = newLeft,
+                            top = newTop,
+                            right = newRight,
+                            bottom = cropRect.bottom
+                        )
+                    } else cropRect
+                } else {
+                    val newTop = (cropRect.top + dragAmount.y).coerceIn(
+                        imageRect.top, cropRect.bottom - minCropSize
+                    )
+                    Rect(
+                        left = cropRect.left, top = newTop,
+                        right = cropRect.right, bottom = cropRect.bottom
+                    )
+                }
             }
 
             DragHandle.Bottom -> {
-                val newOffset = cropRect.bottomLeft + dragAmount
-                val newBottom = newOffset.y.coerceIn(
-                    cropRect.top + minCropSize,
-                    imageRect.bottom
-                )
-                Rect(
-                    left = cropRect.left,
-                    top = cropRect.top,
-                    right = cropRect.right,
-                    bottom = newBottom
-                )
+                if (aspectRatio > 0f) {
+                    val newBottom = (cropRect.bottom + dragAmount.y).coerceIn(
+                        cropRect.top + minCropSize, imageRect.bottom
+                    )
+                    val newHeight = newBottom - cropRect.top
+                    val newWidth = newHeight * aspectRatio
+                    val centerX = cropRect.center.x
+                    val newLeft = centerX - newWidth / 2
+                    val newRight = centerX + newWidth / 2
+                    if (newWidth >= minCropSize && newLeft >= imageRect.left && newRight <= imageRect.right) {
+                        Rect(
+                            left = newLeft,
+                            top = cropRect.top,
+                            right = newRight,
+                            bottom = newBottom
+                        )
+                    } else cropRect
+                } else {
+                    val newBottom = (cropRect.bottom + dragAmount.y).coerceIn(
+                        cropRect.top + minCropSize, imageRect.bottom
+                    )
+                    Rect(
+                        left = cropRect.left, top = cropRect.top,
+                        right = cropRect.right, bottom = newBottom
+                    )
+                }
             }
 
             DragHandle.Left -> {
-                val newOffset = cropRect.bottomLeft + dragAmount
-                val newLeft = newOffset.x.coerceIn(
-                    imageRect.left,
-                    cropRect.right - minCropSize
-                )
-                Rect(
-                    left = newLeft,
-                    top = cropRect.top,
-                    right = cropRect.right,
-                    bottom = cropRect.bottom
-                )
+                if (aspectRatio > 0f) {
+                    val newLeft = (cropRect.left + dragAmount.x).coerceIn(
+                        imageRect.left, cropRect.right - minCropSize
+                    )
+                    val newWidth = cropRect.right - newLeft
+                    val newHeight = newWidth / aspectRatio
+                    val centerY = cropRect.center.y
+                    val newTop = centerY - newHeight / 2
+                    val newBottom = centerY + newHeight / 2
+                    if (newHeight >= minCropSize && newTop >= imageRect.top && newBottom <= imageRect.bottom) {
+                        Rect(
+                            left = newLeft,
+                            top = newTop,
+                            right = cropRect.right,
+                            bottom = newBottom
+                        )
+                    } else cropRect
+                } else {
+                    val newLeft = (cropRect.left + dragAmount.x).coerceIn(
+                        imageRect.left, cropRect.right - minCropSize
+                    )
+                    Rect(
+                        left = newLeft, top = cropRect.top,
+                        right = cropRect.right, bottom = cropRect.bottom
+                    )
+                }
             }
 
             DragHandle.Right -> {
-                val newOffset = cropRect.topRight + dragAmount
-                val newRight = newOffset.x.coerceIn(
-                    cropRect.left + minCropSize,
-                    imageRect.right
-                )
-                Rect(
-                    left = cropRect.left,
-                    top = cropRect.top,
-                    right = newRight,
-                    bottom = cropRect.bottom
-                )
+                if (aspectRatio > 0f) {
+                    val newRight = (cropRect.right + dragAmount.x).coerceIn(
+                        cropRect.left + minCropSize, imageRect.right
+                    )
+                    val newWidth = newRight - cropRect.left
+                    val newHeight = newWidth / aspectRatio
+                    val centerY = cropRect.center.y
+                    val newTop = centerY - newHeight / 2
+                    val newBottom = centerY + newHeight / 2
+                    if (newHeight >= minCropSize && newTop >= imageRect.top && newBottom <= imageRect.bottom) {
+                        Rect(
+                            left = cropRect.left,
+                            top = newTop,
+                            right = newRight,
+                            bottom = newBottom
+                        )
+                    } else cropRect
+                } else {
+                    val newRight = (cropRect.right + dragAmount.x).coerceIn(
+                        cropRect.left + minCropSize, imageRect.right
+                    )
+                    Rect(
+                        left = cropRect.left, top = cropRect.top,
+                        right = newRight, bottom = cropRect.bottom
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
@Tanish-Ranjan I've created a series of branches with improvements that were applied to my inlined library version.

## Description

Side handles (top/bottom/left/right) ignored aspect-ratio locks entirely, and `findActiveHandle` only ever considered corner handles once a shape's ratio was locked, so side handles couldn't be grabbed at all in that mode (see the old `// TODO: Allow cropping with all handles in locked aspect ratios`). `getNewRectMeasures` now recomputes the opposite dimension around the crop rect's center to keep the locked ratio when a side handle moves, and all handles are recognized while dragging regardless of crop shape.

Branch: `fix/aspect-ratio-side-handles` (1 commit)

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] `./gradlew :cropkit:compileDebugKotlin :app:compileDebugKotlin` succeeds
- [ ] Manual testing: lock an aspect ratio (e.g. Square) and drag each side handle, confirm the ratio holds

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
