### PR TITLE
Scale minimum crop size with screen density

### DIFF
--- a/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropStateManager.kt
+++ b/cropkit/src/main/java/com/tanishranjan/cropkit/internal/CropStateManager.kt
@@ -32,6 +32,9 @@ internal class CropStateManager(
     private val handleRadius: Dp,
     private val touchPadding: Dp
 ) {
+    companion object {
+        private const val MIN_CROP_SIZE_DP = 80f
+    }
 
     private val _state = MutableStateFlow(CropState(bitmap))
     val state = _state.asStateFlow()
@@ -39,6 +42,7 @@ internal class CropStateManager(
     private var dragMode: DragMode = DragMode.None
     private val density get() = Resources.getSystem().displayMetrics.density
     private val handleRadiusPx: Float get() = handleRadius.value * density
+    private val minCropSizePx: Float get() = MIN_CROP_SIZE_DP * density
 
     init {
         reset(bitmap)
@@ -181,7 +185,7 @@ internal class CropStateManager(
             dragAmount = adjustedDragAmount,
             imageRect = state.value.imageRect,
             cropRect = state.value.cropRect,
-            minCropSize = MIN_CROP_SIZE
+            minCropSize = minCropSizePx
         )?.let { newRect ->
             _state.update {
                 it.copy(
@@ -373,10 +377,6 @@ internal class CropStateManager(
             )
         }
 
-    }
-
-    companion object {
-        private const val MIN_CROP_SIZE = 250f
     }
 
 }


### PR DESCRIPTION
@Tanish-Ranjan I've created a series of branches with improvements that were applied to my inlined library version.

## Description

The minimum crop size was a raw `250f` pixel constant, so it represented wildly different physical sizes across screen densities. It's now expressed as `80dp` scaled by the display density.

Branch: `perf/density-scaled-min-crop-size` (1 commit)

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] `./gradlew :cropkit:compileDebugKotlin :app:compileDebugKotlin` succeeds
- [ ] Manual testing on devices/emulators with different densities: confirm the crop rectangle can't be shrunk below a consistent physical size

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
